### PR TITLE
Improve reading ADC result

### DIFF
--- a/cores/arduino/wiring_analog.c
+++ b/cores/arduino/wiring_analog.c
@@ -37,7 +37,6 @@ void analogReference(uint8_t mode)
 
 int analogRead(uint8_t pin)
 {
-	uint8_t low, high;
 
 #if defined(analogPinToChannel)
 #if defined(__AVR_ATmega32U4__)
@@ -74,27 +73,20 @@ int analogRead(uint8_t pin)
 	// without a delay, we seem to read from the wrong channel
 	//delay(1);
 
-#if defined(ADCSRA) && defined(ADCL)
+#if defined(ADCSRA) && defined(ADC)
 	// start the conversion
 	sbi(ADCSRA, ADSC);
 
 	// ADSC is cleared when the conversion finishes
 	while (bit_is_set(ADCSRA, ADSC));
 
-	// we have to read ADCL first; doing so locks both ADCL
-	// and ADCH until ADCH is read.  reading ADCL second would
-	// cause the results of each conversion to be discarded,
-	// as ADCL and ADCH would be locked when it completed.
-	low  = ADCL;
-	high = ADCH;
+	// ADC macro takes care of reading ADC register.
+	// avr-gcc implements the proper reading order: ADCL is read first.
+	return ADC;
 #else
 	// we dont have an ADC, return 0
-	low  = 0;
-	high = 0;
+	return 0;
 #endif
-
-	// combine the two bytes
-	return (high << 8) | low;
 }
 
 // Right now, PWM output only works on the pins with


### PR DESCRIPTION
read ADC result with ADC macro instead of readIng ADCL and ADCH separately into `low` and `high` variables and then combining them `return (high<<8) | low `.